### PR TITLE
Fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.0
+numpy
 matplotlib
 tqdm
 ffmpeg-python==0.2.0


### PR DESCRIPTION
Hey 👋 ,

thanks for this tools, really useful :) 

While setting it up I found a few inconsistencies. 

numpy 1.22.0 dropped support for Python < 3.8 (see [release notes](https://numpy.org/devdocs/release/1.22.0-notes.html) ), so the readme is wrong stating Python 3.6+ is required, it should be 3.8-3.10. However, it looks to me that numpy version is too stringent as you're relying only on `std` and `mean`, I bet they work as expected in most versions of numpy :D We can just remove the version and let the dependency system handle that.
